### PR TITLE
Fix bugs with variable parameters and interactions having single participants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+jdks/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PSI-MI XML Maker User Guide
 
-⚠️ It is necessary to download Java 11 **JDK** -> https://adoptium.net/en-GB/temurin/archive/?version=11 
+- ⚠️ It is necessary to download Java 11 **JDK**
+  - https://adoptium.net/en-GB/temurin/releases?version=11
+  - https://www.oracle.com/uk/java/technologies/javase/jdk11-archive-downloads.html
 - Use the installer so it is downloaded directly in the right folder
 
 - Access to the demo: https://drive.google.com/drive/folders/1VftTaAUfWdJF_dyFLEH9b-23i-454qDY?usp=sharing
@@ -103,6 +105,18 @@ Before creating interactions, participants must be defined.
     - Default: `inputFileName_[n].xml` inside a directory named after the input file.
 - Click **Browse...** to change the save location.
 - Click **Create XML File** to generate and save the XML file(s).
+
+## Release
+
+### How to release?
+1. Download the necessary to Java 11 **JDKs** for the supported platforms (macOS x64, macOS aarch64, Windows and Linux x64)
+   - https://adoptium.net/en-GB/temurin/releases?version=11
+   - https://www.oracle.com/uk/java/technologies/javase/jdk11-archive-downloads.html
+2. Extract the JDKs into a `jdks` folder in the root of this project.
+   - Check the names of the folders for each platform match the names specified in the pom.xml file.
+3. Run `mvn package`.
+4. Create a new release in https://github.com/MICommunity/psi-mi-xml-maker/releases.
+   - Upload the generated packages for all the supported platforms to the new release.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,8 @@
             <mainClass>uk.ac.ebi.intact.psi.mi.xmlmaker.XmlMakerGui</mainClass>
             <platform>linux</platform>
             <createTarball>true</createTarball>
-            <packagingJdk>/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home</packagingJdk>
-            <jdkPath>/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home</jdkPath>
+            <packagingJdk>jdks/jdk-11.0.26_linux-x64</packagingJdk>
+            <jdkPath>jdks/jdk-11.0.26_linux-x64</jdkPath>
             <iconFile>src/main/resources/psi.png</iconFile>
           </configuration>
         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>uk.ac.ebi.intact.psi.mi.xmlmaker</groupId>
   <artifactId>PSI-MI-XML-maker</artifactId>
-  <version>1.1</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
 
   <name>PSI-MI-XML-maker</name>

--- a/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/jami/XmlFileWriter.java
+++ b/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/jami/XmlFileWriter.java
@@ -227,7 +227,6 @@ public class XmlFileWriter {
             showErrorDialog("Error during PSI-XML writing, please check that the columns are correctly associated" +
                     "and that the file is correctly formatted. \n" + e.getMessage());
             LOGGER.error("Error during PSI-XML writing", e);
-            e.printStackTrace();
         } finally {
             closeWriter(xmlInteractionWriter);
             if (!skippedParticipants.isEmpty()) {

--- a/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/jami/creators/XmlInteractionsCreator.java
+++ b/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/jami/creators/XmlInteractionsCreator.java
@@ -548,6 +548,9 @@ public class XmlInteractionsCreator {
         IntStream.range(0, descriptions.length).forEach(i -> {
             String desc = descriptions[i];
             String unit = unitsArray[i];
+            if (desc == null || desc.isEmpty() || unit == null || unit.isEmpty()) {
+                return;
+            }
             VariableParameter variableParameter = new XmlVariableParameter();
             variableParameter.setDescription(desc);
             variableParameter.setUnit(fetchTerm(unit));
@@ -557,6 +560,7 @@ public class XmlInteractionsCreator {
             }
             values.stream()
                     .map(String::trim)
+                    .filter(value -> !value.isEmpty())
                     .map(value -> new XmlVariableParameterValue(value, variableParameter))
                     .forEach(variableParameterValue -> variableParameter.getVariableValues()
                             .add(variableParameterValue));
@@ -616,15 +620,16 @@ public class XmlInteractionsCreator {
         }
 
         XmlExperiment experiment = createExperimentForBatch(dataList);
+        XmlInteractionEvidence interaction = new XmlInteractionEvidence();
+        experiment.addInteractionEvidence(interaction);
 
         for (Map<String, String> participant : dataList) {
-            XmlInteractionEvidence interaction = new XmlInteractionEvidence();
             XmlParticipantEvidence newParticipant = createParticipant(participant);
             interaction.addParticipant(newParticipant);
-            experiment.addInteractionEvidence(interaction);
             processInteractionSpecificProperties(interaction, participant);
-            xmlModelledInteractions.add(interaction);
         }
+
+        xmlModelledInteractions.add(interaction);
 
         launchWriting();
     }
@@ -659,11 +664,12 @@ public class XmlInteractionsCreator {
                     for (int i = 0; i < descs.length; i++) {
                         String desc = descs[i].trim();
                         String value = values[i].trim();
-
-                        if (!variableParameterDescAndValues.containsKey(desc)) {
-                            variableParameterDescAndValues.put(desc, new HashSet<>());
+                        if (!desc.isEmpty() && !value.isEmpty()) {
+                            if (!variableParameterDescAndValues.containsKey(desc)) {
+                                variableParameterDescAndValues.put(desc, new HashSet<>());
+                            }
+                            variableParameterDescAndValues.get(desc).add(value);
                         }
-                        variableParameterDescAndValues.get(desc).add(value);
                     }
                 }
             }
@@ -731,15 +737,18 @@ public class XmlInteractionsCreator {
         VariableParameterValueSet variableParameterValueSet = new XmlVariableParameterValueSet();
 
         for (String variableParamDesc : variableParamVDescsArray) {
-            interaction.getExperiment().getVariableParameters().forEach(variableParam -> {
-                if (variableParam.getDescription().equals(variableParamDesc)){
-                    variableParameterValueSet.addAll(variableParam.getVariableValues());
-                }
-            });
+            if (variableParamDesc != null && !variableParamDesc.isEmpty()) {
+                interaction.getExperiment().getVariableParameters().forEach(variableParam -> {
+                    if (variableParam.getDescription().equals(variableParamDesc)) {
+                        variableParameterValueSet.addAll(variableParam.getVariableValues());
+                    }
+                });
+            }
         }
 
-        interaction.getVariableParameterValues().add(variableParameterValueSet);
-
+        if (!variableParameterValueSet.isEmpty()) {
+            interaction.getVariableParameterValues().add(variableParameterValueSet);
+        }
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/utils/VersionUtils.java
+++ b/src/main/java/uk/ac/ebi/intact/psi/mi/xmlmaker/utils/VersionUtils.java
@@ -61,7 +61,7 @@ public class VersionUtils {
     public static void checkForUpdates() {
         String currentVersion = getCurrentVersion();
         try {
-            latestVersion = getString();
+            latestVersion = getLatestReleasedVersion();
             if (latestVersion == null) {
                 LOGGER.warning("Could not find latest version");
                 return;
@@ -69,7 +69,7 @@ public class VersionUtils {
 
             initialiseUrls(latestVersion);
 
-            if (!latestVersion.equals(currentVersion)) {
+            if (isCurrentVersionOlderThanLatestRelease(currentVersion, latestVersion)) {
                 showInfoDialog("Update available! You're on version: " + currentVersion + ", latest version: " + latestVersion);
                 LOGGER.warning("Current version: " + currentVersion + ", latest version: " + latestVersion);
                 downloadDependingOnOs();
@@ -77,6 +77,26 @@ public class VersionUtils {
         } catch (Exception e) {
             LOGGER.warning("Error checking for updates: " + e.getMessage());
         }
+    }
+
+    protected static boolean isCurrentVersionOlderThanLatestRelease(String currentVersion, String releasedVersion) {
+        String[] currentVersionParts = currentVersion.replaceAll("-SNAPSHOT$", "").split("\\.");
+        String[] releasedVersionParts = releasedVersion.replaceAll("-SNAPSHOT$", "").split("\\.");
+
+        int length = Math.max(currentVersionParts.length, releasedVersionParts.length);
+        for (int i = 0; i < length; i++) {
+            int currentVersionPart = i < currentVersionParts.length ? Integer.parseInt(currentVersionParts[i]) : 0;
+            int releasedVersionPart = i < releasedVersionParts.length ? Integer.parseInt(releasedVersionParts[i]) : 0;
+            if (currentVersionPart < releasedVersionPart) {
+                return true;
+            }
+            if (releasedVersionPart < currentVersionPart) {
+                return false;
+            }
+        }
+        // At this point, both versions have the same number, but the current one may be a snapshot
+        // while the released one not.
+        return currentVersion.endsWith("-SNAPSHOT") && !releasedVersion.endsWith("-SNAPSHOT");
     }
 
     /**
@@ -107,7 +127,7 @@ public class VersionUtils {
      * @return the version string (e.g., "1.1.3") if available, or {@code null} if not found or error occurs.
      * @throws IOException if the URL cannot be read or the content is malformed.
      */
-    private static String getString() throws IOException {
+    private static String getLatestReleasedVersion() throws IOException {
         URL url = new URL(VERSION_URL);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");

--- a/src/main/resources/xmlMaker.properties
+++ b/src/main/resources/xmlMaker.properties
@@ -1,1 +1,1 @@
-version=1.1
+version=1.1.1

--- a/src/test/java/uk/ac/ebi/intact/psi/mi/xmlmaker/utils/VersionUtilsTest.java
+++ b/src/test/java/uk/ac/ebi/intact/psi/mi/xmlmaker/utils/VersionUtilsTest.java
@@ -1,0 +1,90 @@
+package uk.ac.ebi.intact.psi.mi.xmlmaker.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VersionUtilsTest {
+
+    @Test
+    public void olderMajorVersion() {
+        assertTrue(VersionUtils.isCurrentVersionOlderThanLatestRelease("1", "2"));
+    }
+
+    @Test
+    public void sameMajorVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1", "1"));
+    }
+
+    @Test
+    public void newerMajorVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("2", "1"));
+    }
+
+    @Test
+    public void newerMajorSnapshotVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("2-SNAPSHOT", "1"));
+    }
+
+    @Test
+    public void olderMinorVersion() {
+        assertTrue(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1", "1.2"));
+    }
+
+    @Test
+    public void sameMinorVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1", "1.1"));
+    }
+
+    @Test
+    public void newerMinorVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.2", "1.1"));
+    }
+
+    @Test
+    public void newerMinorSnapshotVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.2-SNAPSHOT", "1.1"));
+    }
+
+    @Test
+    public void olderPatchVersion() {
+        assertTrue(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.1", "1.1.2"));
+    }
+
+    @Test
+    public void samePatchVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.1", "1.1.1"));
+    }
+
+    @Test
+    public void newerPatchVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.2", "1.1.1"));
+    }
+
+    @Test
+    public void newerPatchSnapshotVersion() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.2-SNAPSHOT", "1.1.1"));
+    }
+
+    @Test
+    public void newerVersionWithPatch() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.1", "1.1"));
+    }
+
+    @Test
+    public void olderVersionWithPatch() {
+        assertTrue(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.1", "1.2"));
+    }
+
+    @Test
+    public void sameVersionCurrentSnapshotReleasedNotSnapshot() {
+        assertTrue(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.2-SNAPSHOT", "1.1.2"));
+    }
+
+    @Test
+    public void sameVersionReleasedSnapshotCurrentNotSnapshot() {
+        assertFalse(VersionUtils.isCurrentVersionOlderThanLatestRelease("1.1.2", "1.1.2-SNAPSHOT"));
+    }
+}
+


### PR DESCRIPTION
We were not properly checking if the variable parameter descriptions and units were empty, so we were creating xml tags like the following one, which caused issued on imports.
```
            <variableParameterList>
              <variableParameter>
                <description></description>
                <variableValueList>
                  <variableValue id="3">
                    <value></value>
                  </variableValue>
                </variableValueList>
              </variableParameter>
            </variableParameterList>
```

Also, a bug was introduced on one of the latest changes and we were creating a new interaction for each participant, which has also been fixed here.

These two fixes have been tested and everything is working as expected now.

I noticed there were no instructions on how to release this, so I added a new section in the Readme about it.